### PR TITLE
Install node 16 in CI workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,8 @@ jobs:
             ${{ runner.os }}-
       - name: Setup Node
         uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
       - name: Backup Yarn install
         run: yarn install --frozen-lockfile
       - name: Set NPM auth token for publishing requirements


### PR DESCRIPTION
## Description
Frequently the dependency install will fail in CI. This seems to be caused by using v18 of node. 
Reverting to 16 seems to resolve this issue.

## Related Issue

## How Has This Been Tested?

## Checklist:
- [ ] I have added this pull request to the Roadmap project
- [ ] I have correctly linked the issue this pull request fixes
- [ ] I have added tests to cover my changes (if appropriate)
- [ ] All new and existing tests passed
- [ ] All database collections, indexes and initial data created
- [ ] All environment variables have been added
